### PR TITLE
chore(date-fns): downgrade to 2.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "country-telephone-data": "^0.6.2",
-    "date-fns": "^2.16.1",
+    "date-fns": "^2.15.0",
     "events": "^3.2.0",
     "lodash": "^4.17.20",
     "sift": "^9.0.0",


### PR DESCRIPTION
Have to downgrade until https://github.com/mui-org/material-ui-pickers/issues/1440 has been addressed by a new version of material-ui-pickers.