### PR TITLE
feat(sift): upgrade to v13.4.0 and refactor queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,8 @@ For example, you can prevent the user from entering _nope@example.com_:
   validators: [
     {
       where: {
-        fields: {
-          email: {
-            value: 'nope@example.com'
-          }
+        'fields.email.value': {
+          value: 'nope@example.com'
         }
       },
       error: {
@@ -115,12 +113,8 @@ For example, you can prevent the user from entering _nope@example.com_:
 Template parameters like `{{fields.email.value}}` can be used to inject the values of fields. And, you can use any [MongoDB-style query](https://docs.mongodb.com/manual/reference/operator/query/) in the `where`. For example, if you had `password` and `retypePassword` fields, you could ensure that they are equivalent with:
 ```js
 where: {
-  retypePassword: {
-    fields: {
-      value: {
-        $ne: '{{fields.password.value}}'
-      }
-    }
+  'retypePassword.fields.value': {
+    $ne: '{{fields.password.value}}'
   },
   error: ...
 }
@@ -160,17 +154,15 @@ listeners: [
       {
         component: 'Set',
         if: {
-          fields: {
-            email: {
-              $or: [
-                {
-                  value: null
-                },
-                {
-                  value: ''
-                }
-              ]
-            }
+          'fields.email': {
+            $or: [
+              {
+                value: null
+              },
+              {
+                value: ''
+              }
+            ]
           }
         },
         name: 'fields.email.value',
@@ -189,17 +181,15 @@ listeners: [
       {
         component: 'Action',
         if: {
-          fields: {
-            email: {
-              $or: [
-                {
-                  value: null
-                },
-                {
-                  value: ''
-                }
-              ]
-            }
+          'fields.email': {
+            $or: [
+              {
+                value: null
+              },
+              {
+                value: ''
+              }
+            ]
           }
         },
         actions: [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "date-fns": "^2.15.0",
     "events": "^3.2.0",
     "lodash": "^4.17.20",
-    "sift": "^9.0.0",
+    "sift": "^13.4.0",
     "text-mask-addons": "^3.8.0",
     "uuid": "^8.3.0",
     "vanilla-text-mask": "^5.1.1"

--- a/scripts/bundle-size.sh
+++ b/scripts/bundle-size.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-maxBytes=335000
+maxBytes=340000
 
 if [ $(wc -c < dist/mson.js) -gt ${maxBytes} ]; then
   echo 'Error: bundle too large!'

--- a/src/actions/action.test.js
+++ b/src/actions/action.test.js
@@ -75,14 +75,8 @@ it('should handle undefined props', async () => {
 it('should filter by globals', async () => {
   const action = new Set({
     if: {
-      globals: {
-        session: {
-          user: {
-            roleNames: {
-              $in: ['admin'],
-            },
-          },
-        },
+      'globals.session.user.roleNames': {
+        $in: ['admin'],
       },
     },
     name: 'value',

--- a/src/actions/action.test.js
+++ b/src/actions/action.test.js
@@ -274,11 +274,7 @@ it('should branch', async () => {
 it('should filter by nested properties', async () => {
   const action = new Set({
     if: {
-      parent: {
-        parent: {
-          name: 'grandparent',
-        },
-      },
+      'parent.parent.name': 'grandparent',
     },
     name: 'value',
     value: 'Jack',

--- a/src/actions/log-in-to-app-and-redirect.js
+++ b/src/actions/log-in-to-app-and-redirect.js
@@ -8,10 +8,8 @@ export default {
     {
       component: 'Action',
       if: {
-        globals: {
-          redirectAfterLogin: {
-            $in: [null, undefined],
-          },
+        'globals.redirectAfterLogin': {
+          $in: [null, undefined],
         },
       },
       actions: [

--- a/src/aggregate/record-editor.test.js
+++ b/src/aggregate/record-editor.test.js
@@ -86,12 +86,8 @@ beforeAll(() => {
     validators: [
       {
         where: {
-          fields: {
-            retypePassword: {
-              value: {
-                $ne: '{{password.value}}',
-              },
-            },
+          'fields.retypePassword.value': {
+            $ne: '{{password.value}}',
           },
         },
         error: {

--- a/src/aggregate/reset-password-editor.js
+++ b/src/aggregate/reset-password-editor.js
@@ -43,12 +43,8 @@ export default {
   validators: [
     {
       where: {
-        fields: {
-          retypePassword: {
-            value: {
-              $ne: '{{fields.password.value}}',
-            },
-          },
+        'fields.retypePassword.value': {
+          $ne: '{{fields.password.value}}',
         },
       },
       error: {

--- a/src/aggregate/signup-editor.js
+++ b/src/aggregate/signup-editor.js
@@ -14,12 +14,8 @@ export default {
   validators: [
     {
       where: {
-        fields: {
-          retypePassword: {
-            value: {
-              $ne: '{{fields.password.value}}',
-            },
-          },
+        'fields.retypePassword.value': {
+          $ne: '{{fields.password.value}}',
         },
       },
       error: {

--- a/src/aggregate/update-password.js
+++ b/src/aggregate/update-password.js
@@ -12,12 +12,8 @@ export default {
   validators: [
     {
       where: {
-        fields: {
-          retypePassword: {
-            value: {
-              $ne: '{{fields.password.value}}',
-            },
-          },
+        'fields.retypePassword.value': {
+          $ne: '{{fields.password.value}}',
         },
       },
       error: {

--- a/src/component/validator.test.js
+++ b/src/component/validator.test.js
@@ -148,11 +148,9 @@ it('should validate with escaped regex', () => {
   let rules = [
     {
       where: {
-        fields: {
-          password: {
-            $not: {
-              $regex: '\\d',
-            },
+        'fields.password': {
+          $not: {
+            $regex: '\\d',
           },
         },
       },

--- a/src/form/form-editor.js
+++ b/src/form/form-editor.js
@@ -42,18 +42,16 @@ export default class FormEditor extends Form {
                 validators: [
                   {
                     where: {
-                      parent: {
-                        value: {
-                          $elemMatch: {
-                            $and: [
-                              {
-                                id: {
-                                  $ne: '{{fields.id.value}}',
-                                },
+                      'parent.value': {
+                        $elemMatch: {
+                          $and: [
+                            {
+                              id: {
+                                $ne: '{{fields.id.value}}',
                               },
-                              { name: '{{fields.name.value}}' },
-                            ],
-                          },
+                            },
+                            { name: '{{fields.name.value}}' },
+                          ],
                         },
                       },
                     },

--- a/src/form/form-validator.test.js
+++ b/src/form/form-validator.test.js
@@ -21,10 +21,8 @@ it('should validate', () => {
   validator.setValues({
     where: {
       fields: {
-        retypePassword: {
-          value: {
-            $ne: '{{fields.password.value}}',
-          },
+        'retypePassword.value': {
+          $ne: '{{fields.password.value}}',
         },
       },
     },
@@ -39,12 +37,8 @@ it('should validate', () => {
 
   validator.setValues({
     where: {
-      fields: {
-        retypePassword: {
-          value: {
-            $invalidOp: '{{fields.password.value}}',
-          },
-        },
+      'fields.retypePassword.value': {
+        $invalidOp: '{{fields.password.value}}',
       },
     },
     error: {
@@ -60,7 +54,7 @@ it('should validate', () => {
       field: 'where',
       error: [
         {
-          error: 'Unknown operation $invalidOp',
+          error: 'Unsupported operation: $invalidOp',
         },
       ],
     },

--- a/src/form/form.nested.test.js
+++ b/src/form/form.nested.test.js
@@ -312,11 +312,7 @@ it('should validate nested form validators', async () => {
     validators: [
       {
         where: {
-          fields: {
-            email: {
-              value: 'scott@example.com',
-            },
-          },
+          'fields.email.value': 'scott@example.com',
         },
         error: {
           field: 'email',
@@ -333,11 +329,7 @@ it('should validate nested form validators', async () => {
       validators: [
         {
           where: {
-            fields: {
-              firstName: {
-                value: 'F. Scott',
-              },
-            },
+            'fields.firstName.value': 'F. Scott',
           },
           error: {
             field: 'firstName',

--- a/src/form/form.test.js
+++ b/src/form/form.test.js
@@ -274,11 +274,7 @@ it('should validate schema', () => {
     validators: [
       {
         where: {
-          fields: {
-            name: {
-              value: 'F. Scott Fitzgerald',
-            },
-          },
+          'fields.name.value': 'F. Scott Fitzgerald',
         },
         error: {
           field: 'name',
@@ -758,11 +754,7 @@ it('should elevate', async () => {
     validators: [
       {
         where: {
-          fields: {
-            lastName: {
-              value: 'Vader',
-            },
-          },
+          'fields.lastName.value': 'Vader',
         },
         error: {
           field: 'lastName',

--- a/src/form/form.validators.test.js
+++ b/src/form/form.validators.test.js
@@ -15,10 +15,8 @@ const createForm = () => {
     validators: [
       {
         where: {
-          fields: {
-            firstName: {
-              value: 'Jim',
-            },
+          'fields.firstName': {
+            value: 'Jim',
           },
         },
         error: {
@@ -28,12 +26,8 @@ const createForm = () => {
       },
       {
         where: {
-          fields: {
-            lastName: {
-              value: {
-                $eq: 'Jones',
-              },
-            },
+          'fields.lastName.value': {
+            $eq: 'Jones',
           },
         },
         error: {
@@ -43,12 +37,8 @@ const createForm = () => {
       },
       {
         where: {
-          fields: {
-            middleName: {
-              value: {
-                $eq: '{{fields.firstName.value}}',
-              },
-            },
+          'fields.middleName.value': {
+            $eq: '{{fields.firstName.value}}',
           },
         },
         error: {

--- a/src/form/form.validators.test.js
+++ b/src/form/form.validators.test.js
@@ -15,9 +15,7 @@ const createForm = () => {
     validators: [
       {
         where: {
-          'fields.firstName': {
-            value: 'Jim',
-          },
+          'fields.firstName.value': 'Jim',
         },
         error: {
           field: 'firstName',

--- a/yarn.lock
+++ b/yarn.lock
@@ -12564,9 +12564,10 @@ side-channel@^1.0.2:
     es-abstract "^1.17.0-next.1"
     object-inspect "^1.7.0"
 
-sift@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/sift/-/sift-9.0.0.tgz#6161a8a8c715fab28fb6044199137e8d3b521eae"
+sift@^13.4.0:
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-13.4.0.tgz#859741aa76421dadc6cf07c0634088cbb120d0d3"
+  integrity sha512-sJAs3ujQjx6QVzWPKmqK1LhTAnpEiP2Q7zJi4VSmRYGAuz9SmlyAzo8w4jJQrrGXJb/QNUd0iJvD17dRezzfAA==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
BREAKING CHANGE: The latest version of sift makes it function more like MongoDB, specifically moving away from the
ability to define nested queries. MongoDB does this to create a boundary between the query language
and the data. In turn, this will break the ability to specify nested queries in MSON.

For example, previous to this change, you could specify the following query:
```
{
  fields: {
    firstName: {
      value: {
        $eq: "Jimmy"
      }
    }
  }
}
```
After this change, you'll need to refactor the query to be in the form of:
```
{
  "fields.firstName.value": {
    $eq: "Jimmy"
  }
}
```

Note: this affects any areas in MSON that support queries, including the `if` clause in an Action.

See https://github.com/crcn/sift.js/issues/206 & https://github.com/redgeoff/mson/issues/254 for more information

fix #254