### PR TITLE
feat(mingo): migrate from sift

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "date-fns": "^2.15.0",
     "events": "^3.2.0",
     "lodash": "^4.17.20",
-    "sift": "^13.4.0",
+    "mingo": "^4.1.0",
     "text-mask-addons": "^3.8.0",
     "uuid": "^8.3.2",
     "vanilla-text-mask": "^5.1.1"

--- a/scripts/bundle-size.sh
+++ b/scripts/bundle-size.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-maxBytes=350000
+maxBytes=421000
 
 if [ $(wc -c < dist/mson.js) -gt ${maxBytes} ]; then
   echo 'Error: bundle too large!'

--- a/src/compiler/query.js
+++ b/src/compiler/query.js
@@ -1,9 +1,24 @@
-import sift from 'sift';
+import { Aggregator } from 'mingo/aggregator';
+import 'mingo/init/system';
+import mingo from 'mingo';
+
+// We can support tree shaking and cherry pick operators, but all the operators in Mingo are useful,
+// depending on your use case. Moreover, the largeness of Mingo's bundle size is mostly due to its
+// operators, therefore it isn't possible to exclude other core mingo functionality. For now, we'll
+// choose not to make any such cherry-picking optimizations.
+
+// import "mingo/init/basic";
+// import { useOperators, OperatorType } from "mingo/core";
+// import { $cond } from "mingo/operators/expression";
+// useOperators(OperatorType.EXPRESSION, { $cond });
 
 export const filter = (collection, query) => {
-  return collection.filter(sift(query));
+  const q = new mingo.Query(query);
+  const cursor = q.find(collection);
+  return cursor.all();
 };
 
 export const validateQuery = (query) => {
-  sift(query);
+  const q = new mingo.Query(query);
+  q.test([]);
 };

--- a/src/compiler/query.js
+++ b/src/compiler/query.js
@@ -1,4 +1,3 @@
-import { Aggregator } from 'mingo/aggregator';
 import 'mingo/init/system';
 import mingo from 'mingo';
 

--- a/src/form/form-editor.js
+++ b/src/form/form-editor.js
@@ -44,14 +44,10 @@ export default class FormEditor extends Form {
                     where: {
                       'parent.value': {
                         $elemMatch: {
-                          $and: [
-                            {
-                              id: {
-                                $ne: '{{fields.id.value}}',
-                              },
-                            },
-                            { name: '{{fields.name.value}}' },
-                          ],
+                          id: {
+                            $ne: '{{fields.id.value}}',
+                          },
+                          name: '{{fields.name.value}}',
                         },
                       },
                     },

--- a/src/form/form-validator.test.js
+++ b/src/form/form-validator.test.js
@@ -54,7 +54,8 @@ it('should validate', () => {
       field: 'where',
       error: [
         {
-          error: 'Unsupported operation: $invalidOp',
+          // error: 'Unsupported operation: $invalidOp', // sift
+          error: 'unknown operator $invalidOp', // mingo
         },
       ],
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9058,6 +9058,11 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+mingo@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/mingo/-/mingo-4.1.0.tgz#130c741c3b548c0e4033dab76360d731bc7ae289"
+  integrity sha512-T+w8N5N5YoWC9bospMA87D4dAPuSS7RSmEetdcbxDNEGINDdimISG2At9/lk1YsyvZibDif2bvGvbXcjBZWTew==
+
 mini-css-extract-plugin@0.11.3:
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz#15b0910a7f32e62ffde4a7430cfefbd700724ea6"
@@ -9337,10 +9342,10 @@ node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-forge@0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
+  integrity sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==
 
 node-gyp@^5.0.2, node-gyp@^5.1.0:
   version "5.1.1"
@@ -12410,11 +12415,6 @@ side-channel@^1.0.2:
   dependencies:
     es-abstract "^1.17.0-next.1"
     object-inspect "^1.7.0"
-
-sift@^13.4.0:
-  version "13.4.0"
-  resolved "https://registry.yarnpkg.com/sift/-/sift-13.4.0.tgz#859741aa76421dadc6cf07c0634088cbb120d0d3"
-  integrity sha512-sJAs3ujQjx6QVzWPKmqK1LhTAnpEiP2Q7zJi4VSmRYGAuz9SmlyAzo8w4jJQrrGXJb/QNUd0iJvD17dRezzfAA==
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
We are migrating from sift to [mingo](https://github.com/kofrasa/mingo) as mingo supports aggregations that will soon be used to power Template Parameter Queries, i.e. Mongo DB aggregations can be used to dynamically set values. See https://github.com/redgeoff/mson/issues/200 for some high-level initial discovery.

The bundle size is jumping quite a bit with this switch, but the amount of capability that we are adding makes this well worth the bundle size increase.