### PR TITLE
feat(template-parameters): support mongo aggregation queries

### DIFF
--- a/scripts/bundle-size.sh
+++ b/scripts/bundle-size.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-maxBytes=421000
+maxBytes=422000
 
 if [ $(wc -c < dist/mson.js) -gt ${maxBytes} ]; then
   echo 'Error: bundle too large!'

--- a/src/actions/action.js
+++ b/src/actions/action.js
@@ -95,7 +95,7 @@ export default class Action extends Component {
 
     if (where) {
       this._setWhereProps(where, props);
-      let filtered = filter([this._whereProps], where);
+      const filtered = filter([this._whereProps], where);
       if (filtered.length === 0) {
         // Condition failed
         if (this.get('else')) {

--- a/src/actions/action.js
+++ b/src/actions/action.js
@@ -52,24 +52,26 @@ export default class Action extends Component {
   // Abstract method
   // async act(/* props */) {}
 
-  _fill(prop) {
+  _fill(prop, preventAggregation) {
     const propFiller = new PropFiller(this._fillerProps);
 
     // Fill with props from component first so that we define default values in the component like
     // {{fields.to.value}} that are then filled via the second fill.
-    prop = propFiller.fill(prop);
-    prop = propFiller.fill(prop); // Yes, this duplicate is needed!
+    prop = propFiller.fill(prop, preventAggregation);
+    prop = propFiller.fill(prop, preventAggregation); // Yes, this duplicate is needed!
 
     return prop;
   }
 
-  _getFilled(names) {
+  _getFilled(names, preventAggregation) {
     let prop = super.get(names);
-    return prop === undefined ? undefined : this._fill(prop);
+    return prop === undefined
+      ? undefined
+      : this._fill(prop, preventAggregation);
   }
 
-  get(names) {
-    return this._getFilled(names);
+  get(names, preventAggregation) {
+    return this._getFilled(names, preventAggregation);
   }
 
   _setFillerProps(props) {
@@ -87,13 +89,13 @@ export default class Action extends Component {
   async run(props) {
     this._setFillerProps(props);
 
-    const where = this.get('if');
+    const where = this.get('if', true);
     let shouldRun = true;
     let actions = null;
 
     if (where) {
       this._setWhereProps(where, props);
-      const filtered = filter([this._whereProps], where);
+      let filtered = filter([this._whereProps], where);
       if (filtered.length === 0) {
         // Condition failed
         if (this.get('else')) {

--- a/src/actions/get-docs.js
+++ b/src/actions/get-docs.js
@@ -25,7 +25,7 @@ export default class GetDocs extends Action {
 
   async act(/* props */) {
     return this.get('store').getAllDocs({
-      where: this.get('where'),
+      where: this.get('where', true),
     });
   }
 }

--- a/src/compiler/prop-filler.js
+++ b/src/compiler/prop-filler.js
@@ -1,7 +1,7 @@
 // TODO: move from compiler directory as used by multiple modules
 
 import cloneDeepWith from 'lodash/cloneDeepWith';
-
+import { resolveAnyAggregation } from './query';
 export default class PropFiller {
   constructor(props) {
     this.setProps(props);
@@ -88,11 +88,20 @@ export default class PropFiller {
     });
   }
 
-  fill(obj) {
+  fill(obj, preventAggregation) {
     if (typeof obj === 'string') {
       return this.fillString(obj);
     } else {
-      return this.fillAll(obj);
+      const filledObj = this.fillAll(obj);
+
+      if (preventAggregation) {
+        return filledObj;
+      } else {
+        // We choose to execute the Mongo query in this layer instead of BaseComponent._setProperty()
+        // as BaseComponent._setProperty() is called far more frequently and we want to avoid the
+        // unneeded overhead.
+        return resolveAnyAggregation(filledObj);
+      }
     }
   }
 }

--- a/src/compiler/query.js
+++ b/src/compiler/query.js
@@ -1,3 +1,4 @@
+import { Aggregator } from 'mingo/aggregator';
 import 'mingo/init/system';
 import mingo from 'mingo';
 
@@ -10,6 +11,59 @@ import mingo from 'mingo';
 // import { useOperators, OperatorType } from "mingo/core";
 // import { $cond } from "mingo/operators/expression";
 // useOperators(OperatorType.EXPRESSION, { $cond });
+
+const getFirstKey = (obj) => {
+  // Note: https://gist.github.com/redgeoff/13e3cb9c9e5a0982529ea3a8cd755382 proves that using
+  // Object.keys() is faster than lodash's each with a short circuit
+  return Object.keys(obj)[0];
+};
+
+const isOperator = (key) => {
+  // If the key starts with $ then assume it is an operator. This is the same method that mingo
+  // uses:
+  // https://github.com/kofrasa/mingo/blob/924e8f5d1411a5879983de6c986dfdaf12bcb459/src/util.ts#L890
+  return typeof key === 'string' && key[0] === '$';
+};
+
+const isAggregation = (obj) => {
+  // Is the first key in the object an operator? e.g.
+  // {
+  //   $cond: [
+  //     {
+  //       $eq: ['{{value}}', 'Jack']
+  //     },
+  //     'is Jack',
+  //     'is Jill'
+  //   ]
+  // }
+  //
+  // We use this to determine if obj is an aggregation. An alternative to this would be
+  // to accept values like `{ mongo: <query> }`, but that adds a lot of bloat.
+  const firstKey = getFirstKey(obj);
+  return firstKey !== undefined && isOperator(firstKey);
+};
+
+export const resolveAnyAggregation = (obj) => {
+  if (isAggregation(obj)) {
+    const agg = new Aggregator([
+      {
+        $project: {
+          value: obj,
+        },
+      },
+    ]);
+
+    // We use an empty collection as substitution of parameters is handled by MSON's template
+    // parameters, which are swapped out before the mingo query is run
+    const collection = [{}];
+
+    const result = agg.run(collection);
+
+    return result && result[0] && result[0].value;
+  } else {
+    return obj;
+  }
+};
 
 export const filter = (collection, query) => {
   const q = new mingo.Query(query);


### PR DESCRIPTION
Template Parameter Queries use Mongo DB aggregations to dynamically set values. See #200 for some high-level initial discovery.

For example we can do things like the following and much more as we now have a powerful rendering language built into the template parameters:
```
{
  component: 'Set',
  name: 'foo',
  value: {
    bar: {
      $not: '{{foo.bar}}'
    },
    count: {
      $add: ['{{foo.count}}', 1],
    }
  }
}
```

