### PR TITLE
feat(date-field): customize format

### DIFF
--- a/src/fields/date-field.js
+++ b/src/fields/date-field.js
@@ -33,6 +33,14 @@ export default class DateField extends Field {
             label: 'Max Date',
             docLevel: 'basic',
           },
+          {
+            name: 'format',
+            component: 'TextField',
+            label: 'Format',
+            docLevel: 'basic',
+            help:
+              'Customize date format, e.g. "yyyy-MM-dd" or "d MMM yyyy". See https://date-fns.org/',
+          },
         ],
       },
     });


### PR DESCRIPTION
Customize date format via a string. This helpful for localization. See https://date-fns.org/v2.17.0/docs/format for date formats.

Fixes https://github.com/redgeoff/mson-react/issues/251