### PR TITLE
fix(git-hooks): use prepare so not run by consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "analyze-bundle": "webpack --json > ./dist/stats.json && webpack-bundle-analyzer ./dist/stats.json",
     "prepublishOnly": "yarn compile && yarn bundle",
     "semantic-release": "semantic-release",
-    "postinstall": "git config core.hooksPath ./git-hooks"
+    "prepare": "git config core.hooksPath ./git-hooks"
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
If we switch to using npm's `prepare` hook, it will only be run when `npm install` is [run locally](https://docs.npmjs.com/cli/v7/using-npm/scripts#life-cycle-scripts)

> Runs on local npm install without any arguments