### PR TITLE
Revert "fix(compiler): prevent prototype pollution"

### DIFF
--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -217,11 +217,7 @@ export class Compiler {
     // Descend all the way down the tree and then start instantiating on the way up
     each(props, (prop, name) => {
       if (typeof prop === 'object' && prop !== null) {
-        // Prevent prototype pollution by prohibiting any names that begin with an underscore, e.g.
-        // `__proto__`: https://github.com/redgeoff/mson/security/code-scanning/2
-        if (typeof name !== 'string' || !name.startsWith('_')) {
-          props[name] = this._instantiate(prop);
-        }
+        props[name] = this._instantiate(prop);
       }
     });
 

--- a/src/compiler/compiler.test.js
+++ b/src/compiler/compiler.test.js
@@ -783,31 +783,3 @@ it('should register components with index name', async () => {
   compiler.registerComponents(components);
   expect(compiler.exists('app.FooIt')).toEqual(true);
 });
-
-it('should not allow prototype pollution', async () => {
-  // Ensure that no user specified names, e.g. `__proto__`, can result in hijacking
-  // Object.prototype. To accomplish this, the compiler does not instantiate any names starting with
-  // an underscore. We use `__proto` instead of `__proto__` as use of __proto__ will result in the
-  // code bombing out in another way.
-
-  const definition = {
-    component: 'Component',
-  };
-
-  const Component = compiler.compile({
-    component: 'Component',
-    schema: {
-      component: 'Form',
-      fields: [
-        {
-          name: '__proto',
-          component: 'Field',
-        },
-      ],
-    },
-  });
-
-  const component = new Component({ name: 'foo', __proto: definition });
-
-  expect(component.get('__proto')).toEqual(definition);
-});


### PR DESCRIPTION
Reverts redgeoff/mson#541

This fixes the vulnerability, but not in the eyes of CodeQL, so we'll try another approach.