### PR TITLE
fix(component): bug when extending legacy notation

### DIFF
--- a/src/component/component.test.js
+++ b/src/component/component.test.js
@@ -40,7 +40,6 @@ class CondensedExtendedLegacyNotationComponent extends LegacyNotationComponent {
   constructor(props) {
     super({
       name: 'app.CondensedExtendedLegacyNotationComponent',
-      docLevel: 'basic',
       ...props,
     });
   }
@@ -56,7 +55,7 @@ it('should support condensed extended legacy component notation', () => {
   );
 });
 
-// Condensed notation where everything is in a single create() call
+// Condensed notation where everything is in a single constructor() call
 class CondensedNotationComponent extends Component {
   constructor(props) {
     super({
@@ -70,6 +69,23 @@ class CondensedNotationComponent extends Component {
 it('should support condensed component notation', () => {
   const component = new CondensedNotationComponent({ isStore: true });
   shouldSupportComponentNotations(component, 'app.CondensedNotationComponent');
+});
+
+class ExtendedCondensedNotationComponent extends CondensedNotationComponent {
+  constructor(props) {
+    super({
+      name: 'app.ExtendedCondensedNotationComponent',
+      ...props,
+    });
+  }
+}
+
+it('should support extended condensed component notation', () => {
+  const component = new ExtendedCondensedNotationComponent({ isStore: true });
+  shouldSupportComponentNotations(
+    component,
+    'app.ExtendedCondensedNotationComponent'
+  );
 });
 
 const createFunctionalNotationComponent = (props) =>

--- a/src/component/component.test.js
+++ b/src/component/component.test.js
@@ -36,6 +36,26 @@ it('should support legacy component notation', () => {
   shouldSupportComponentNotations(component, 'app.LegacyNotationComponent');
 });
 
+class CondensedExtendedLegacyNotationComponent extends LegacyNotationComponent {
+  constructor(props) {
+    super({
+      name: 'app.CondensedExtendedLegacyNotationComponent',
+      docLevel: 'basic',
+      ...props,
+    });
+  }
+}
+
+it('should support condensed extended legacy component notation', () => {
+  const component = new CondensedExtendedLegacyNotationComponent({
+    isStore: true,
+  });
+  shouldSupportComponentNotations(
+    component,
+    'app.CondensedExtendedLegacyNotationComponent'
+  );
+});
+
 // Condensed notation where everything is in a single create() call
 class CondensedNotationComponent extends Component {
   constructor(props) {

--- a/src/component/component.test.js
+++ b/src/component/component.test.js
@@ -36,26 +36,29 @@ it('should support legacy component notation', () => {
   shouldSupportComponentNotations(component, 'app.LegacyNotationComponent');
 });
 
-class CondensedExtendedLegacyNotationComponent extends LegacyNotationComponent {
-  constructor(props) {
-    super({
-      name: 'app.CondensedExtendedLegacyNotationComponent',
-      ...props,
-    });
-  }
-}
+// As per https://github.com/redgeoff/mson/pull/570#issuecomment-1014153789, it is not possible to
+// use the condensed notation when extending a component that uses the legacy notation.
+//
+// class CondensedExtendedLegacyNotationComponent extends LegacyNotationComponent {
+//   constructor(props) {
+//     super({
+//       name: 'app.CondensedExtendedLegacyNotationComponent',
+//       ...props,
+//     });
+//   }
+// }
+//
+// it('should support condensed extended legacy component notation', () => {
+//   const component = new CondensedExtendedLegacyNotationComponent({
+//     isStore: true,
+//   });
+//   shouldSupportComponentNotations(
+//     component,
+//     'app.CondensedExtendedLegacyNotationComponent'
+//   );
+// });
 
-it('should support condensed extended legacy component notation', () => {
-  const component = new CondensedExtendedLegacyNotationComponent({
-    isStore: true,
-  });
-  shouldSupportComponentNotations(
-    component,
-    'app.CondensedExtendedLegacyNotationComponent'
-  );
-});
-
-// Condensed notation where everything is in a single constructor() call
+// Condensed notation where everything is in a single call to super()
 class CondensedNotationComponent extends Component {
   constructor(props) {
     super({


### PR DESCRIPTION
The new [condensed notation](https://github.com/redgeoff/mson/pull/569) doesn't work when you extend a component with the legacy notation. This issue was detected by https://github.com/redgeoff/mson-react/pull/316