### PR TITLE
test(component): condensed notation will overwrite schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,13 +533,13 @@ class MyComponent extends Component {
       name: 'MyComponent',
 
       // Define a currentDay property
-      schema: new Form(
+      schema: new Form({
         fields: [
           new TextField({
             name: 'currentDay'
           })
         ]
-      ),
+      }),
 
       // Default currentDay
       currentDay: moment().format('dddd'),
@@ -564,13 +564,13 @@ class MyAction extends Action {
   constructor(props) {
     super({
       name: 'MyAction',
-      schema: new Form(
+      schema: new Form({
         fields: [
           new TextField({
             name: 'foo'
           })
         ]
-      )
+      })
     })
   }
 

--- a/src/component/component.test.js
+++ b/src/component/component.test.js
@@ -1,4 +1,6 @@
 import Component from './component';
+import Form from '../form/form';
+import TextField from '../fields/text-field';
 
 it('should concat schemas', () => {
   const c = new Component({
@@ -19,7 +21,16 @@ const shouldSupportComponentNotations = (component, className) => {
   expect(component.get('isStore')).toEqual(true);
   expect(component.get('docLevel')).toEqual('basic');
   expect(component.getClassName()).toEqual(className);
+  expect(component.get('song')).toEqual('Bamboleo');
 };
+
+const songField = new TextField({
+  name: 'song',
+});
+
+const artistField = new TextField({
+  name: 'artist',
+});
 
 // Legacy notation where className is specified separately
 class LegacyNotationComponent extends Component {
@@ -27,12 +38,20 @@ class LegacyNotationComponent extends Component {
 
   create(props) {
     super.create(props);
-    this.set({ docLevel: 'basic' });
+    this.set({
+      schema: new Form({
+        fields: [songField],
+      }),
+      docLevel: 'basic',
+    });
   }
 }
 
 it('should support legacy component notation', () => {
-  const component = new LegacyNotationComponent({ isStore: true });
+  const component = new LegacyNotationComponent({
+    isStore: true,
+    song: 'Bamboleo',
+  });
   shouldSupportComponentNotations(component, 'app.LegacyNotationComponent');
 });
 
@@ -41,6 +60,9 @@ class CondensedNotationComponent extends Component {
   constructor(props) {
     super({
       name: 'app.CondensedNotationComponent',
+      schema: new Form({
+        fields: [songField],
+      }),
       docLevel: 'basic',
       ...props,
     });
@@ -48,18 +70,71 @@ class CondensedNotationComponent extends Component {
 }
 
 it('should support condensed component notation', () => {
-  const component = new CondensedNotationComponent({ isStore: true });
+  const component = new CondensedNotationComponent({
+    isStore: true,
+    song: 'Bamboleo',
+  });
   shouldSupportComponentNotations(component, 'app.CondensedNotationComponent');
+});
+
+class ExtendedCondensedNotationComponent extends CondensedNotationComponent {
+  className = 'app.ExtendedCondensedNotationComponent';
+
+  // NOTE: we need to call this.set() after super.create() so that we don't overwrite the schema set
+  // in CondensedNotationComponent
+  create(props) {
+    // this.className = 'app.ExtendedCondensedNotationComponent';
+    super.create(props);
+    this.set({
+      // name: 'app.ExtendedCondensedNotationComponent',
+      schema: new Form({
+        fields: [artistField],
+      }),
+    });
+  }
+}
+
+// THIS DOESN'T WORK
+//
+// class ExtendedCondensedNotationComponent extends CondensedNotationComponent {
+//   constructor(props) {
+//     super(props);
+//     this.set({
+//       name: 'app.ExtendedCondensedNotationComponent',
+//       schema: new Form({
+//         fields: [artistField]
+//       })
+//     });
+//   }
+// }
+
+it('should support extended condensed component notation', () => {
+  const component = new ExtendedCondensedNotationComponent({
+    isStore: true,
+    song: 'Bamboleo',
+    artist: 'Gipsy Kings',
+  });
+  shouldSupportComponentNotations(
+    component,
+    'app.ExtendedCondensedNotationComponent'
+  );
+  expect(component.get('artist')).toEqual('Gipsy Kings');
 });
 
 const createFunctionalNotationComponent = (props) =>
   new Component({
     name: 'app.FunctionalNotationComponent',
+    schema: new Form({
+      fields: [songField],
+    }),
     docLevel: 'basic',
     ...props,
   });
 
 it('should support functional component notation', () => {
-  const component = createFunctionalNotationComponent({ isStore: true });
+  const component = createFunctionalNotationComponent({
+    isStore: true,
+    song: 'Bamboleo',
+  });
   shouldSupportComponentNotations(component, 'app.FunctionalNotationComponent');
 });

--- a/src/component/component.test.js
+++ b/src/component/component.test.js
@@ -78,6 +78,7 @@ it('should support condensed component notation', () => {
 });
 
 class ExtendedCondensedNotationComponent extends CondensedNotationComponent {
+  // TODO: could this be moved to set if we introduce className as a property?
   className = 'app.ExtendedCondensedNotationComponent';
 
   // NOTE: we need to call this.set() after super.create() so that we don't overwrite the schema set
@@ -121,15 +122,19 @@ it('should support extended condensed component notation', () => {
   expect(component.get('artist')).toEqual('Gipsy Kings');
 });
 
-const createFunctionalNotationComponent = (props) =>
-  new Component({
-    name: 'app.FunctionalNotationComponent',
+const createFunctionalNotationComponent = (props) => {
+  const component = new Component();
+  component.className = 'app.FunctionalNotationComponent';
+  component.set({
+    // name: 'app.FunctionalNotationComponent', // className instead?
     schema: new Form({
       fields: [songField],
     }),
     docLevel: 'basic',
     ...props,
   });
+  return component;
+};
 
 it('should support functional component notation', () => {
   const component = createFunctionalNotationComponent({
@@ -137,4 +142,31 @@ it('should support functional component notation', () => {
     song: 'Bamboleo',
   });
   shouldSupportComponentNotations(component, 'app.FunctionalNotationComponent');
+});
+
+// TODO: make component.set() return component so that can chain?
+const createExtendedFunctionalNotationComponent = (props) => {
+  const component = createFunctionalNotationComponent();
+  component.className = 'app.ExtendedFunctionalNotationComponent';
+  component.set({
+    // name: 'app.ExtendedFunctionalNotationComponent',
+    schema: new Form({
+      fields: [artistField],
+    }),
+    ...props,
+  });
+  return component;
+};
+
+it('should support extended functional component notation', () => {
+  const component = createExtendedFunctionalNotationComponent({
+    isStore: true,
+    song: 'Bamboleo',
+    artist: 'Gipsy Kings',
+  });
+  shouldSupportComponentNotations(
+    component,
+    'app.ExtendedFunctionalNotationComponent'
+  );
+  expect(component.get('artist')).toEqual('Gipsy Kings');
 });


### PR DESCRIPTION
The condensed notation support introduced by https://github.com/redgeoff/mson/pull/569, overwrites the schema when a derived component specifies a schema. Ultimately, this probably means that we cannot support this notation.

Specifically, we need https://github.com/redgeoff/mson/pull/571/files#diff-63bd7813ac255f841a13b8f1405bd3d8065aa00be44f49b77021df1e5128ff04R80 and NOT https://github.com/redgeoff/mson/pull/571/files#diff-63bd7813ac255f841a13b8f1405bd3d8065aa00be44f49b77021df1e5128ff04R99